### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -4,8 +4,8 @@
 
 IPv4Util	KEYWORD1
 
-onSameNetwork		KEYWORD2
-isZeroNetworkBroadcast KEYWORD2
+onSameNetwork	KEYWORD2
+isZeroNetworkBroadcast	KEYWORD2
 getClassOfNetwork	KEYWORD2
 getNetworkAddress	KEYWORD2
 getBroadcastAddress	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords